### PR TITLE
Change check_dots_unnamed to ignore argument `...`

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -71,12 +71,16 @@ check_dots_unnamed <- function(env = parent.frame(), action = abort) {
     return()
   }
 
-  unnamed <- is.na(names(proms))
+  if (any(names(proms) == "...")) {
+    message(paste("Please don't name argument `...`."))
+    }
+  
+  unnamed <- is.na(names(proms[names(proms) != "..."]))
   if (all(unnamed)) {
     return(invisible())
   }
 
-  named <- names(proms)[!unnamed]
+  named <- names(proms[names(proms) != "..."])[!unnamed]
   action_dots(
     action = action,
     message = paste0(length(named), " components of `...` had unexpected names."),


### PR DESCRIPTION
Changed check_dots_unnamed to allow for arguments named `...`. This is clearly (to me, now) bad form, but technically there shouldn't be any real issue with a user explicitly naming their arguments `...`. This had previously worked quite nicely when piping into gather with data %>% gather(... =  grep(names(.), pattern = "pattern"))